### PR TITLE
Swift 2 ready and cleanup in Response class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: objective-c
 osx_image: xcode7
 
 script:
-  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient -sdk iphonesimulator
+  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: objective-c
 osx_image: xcode7
 
 script:
-  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient
+  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: objective-c
 osx_image: xcode7
 
 script:
-  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient
+  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient -sdk iphonesimulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode6.4
+osx_image: xcode7
 
 script:
   - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: objective-c
 osx_image: xcode7
 
 script:
-  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+  - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SwiftClient [![Build Status](https://travis-ci.org/theadam/SwiftClient.png)](https://travis-ci.org/theadam/SwiftClient)
-A Simple HTTP Client written in Swift
+A Simple HTTP Client written in Swift 2.
 
 ## Installation
 1. If you are using git then add SwiftClient as a submodule using `git submodule add https://github.com/theadam/SwiftClient.git` otherwise download the project using `git clone https://github.com/theadam/SwiftClient.git` in your project folder.
@@ -176,7 +176,7 @@ Client().get(url).end(responseHandler, onError: errorHandler); // Overrides all 
 ```
 ## Response
 #### Fields
-`response.status` - The HTTP response status code.
+`response.status` - The HTTP response status code (Response.ResponseType).
 
 `response.text` - An optional string containing the text of the body of the response.
 
@@ -186,29 +186,7 @@ Client().get(url).end(responseHandler, onError: errorHandler); // Overrides all 
 
 `response.headers` - A dictionary of string to string containing the headers of the response.
 
-#### status code helpers
-Each of these booleans are helpers to determine the status of the Response
-
-`info` - 1xx
-
-`ok` - 2xx
-
-`clientError` - 4xx
-
-`serverError` - 5xx
-
-`error` - 4xx/5xx
-
-`accepted` - 202
-
-`noContent` - 404
-
-`badRequest` - 400
-
-`unauthorized` - 401
-
-`notAcceptable` - 406
-
-`notFound` - 404
-
-`forbidden` - 403
+## ResponseType
+ResponseType is a new enumeration brought into the client. Instead of having countless, memory allocated, booleans, we've got an enumeration. As before, you will be able to check all of the previously used HTTP status codes.  
+### BasicResponseType
+Enumeration based on statusType.

--- a/SwiftClient.xcodeproj/project.pbxproj
+++ b/SwiftClient.xcodeproj/project.pbxproj
@@ -175,7 +175,8 @@
 		D0CB88CD19FC645300DA6940 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Adam Nalisnick";
 				TargetAttributes = {
 					D0CB88D519FC645300DA6940 = {
@@ -276,6 +277,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
@@ -357,6 +359,7 @@
 				INFOPLIST_FILE = SwiftClient/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "theadam.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -374,6 +377,7 @@
 				INFOPLIST_FILE = SwiftClient/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "theadam.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -392,6 +396,7 @@
 				);
 				INFOPLIST_FILE = SwiftClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "theadam.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -405,6 +410,7 @@
 				);
 				INFOPLIST_FILE = SwiftClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "theadam.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/SwiftClient.xcodeproj/xcshareddata/xcschemes/SwiftClient.xcscheme
+++ b/SwiftClient.xcodeproj/xcshareddata/xcschemes/SwiftClient.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:SwiftClient.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/SwiftClient/Constants.swift
+++ b/SwiftClient/Constants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal func base64Encode(string:String) -> String {
-    return dataToString(stringToData(string).base64EncodedDataWithOptions(nil))
+    return dataToString(stringToData(string).base64EncodedDataWithOptions([]))
 }
 
 internal func uriDecode(string:String) -> String{
@@ -37,7 +37,7 @@ internal func queryString(query:AnyObject) -> String?{
     if let dict = query as? Dictionary<String, AnyObject> {
         pairs = Array()
         for (key, value) in dict {
-            pairs!.append(queryPair(key, value))
+            pairs!.append(queryPair(key, value: value))
         }
     }
     else if let array = query as? [String] {
@@ -45,7 +45,7 @@ internal func queryString(query:AnyObject) -> String?{
     }
     
     if let pairs = pairs {
-        return "&".join(pairs)
+        return pairs.joinWithSeparator("&")
     }
     
     return nil
@@ -53,8 +53,12 @@ internal func queryString(query:AnyObject) -> String?{
 
 // PARSERS
 private func parseJson(data:NSData, string: String) -> AnyObject?{
-    var error:NSError?
-    return NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(), error: &error)
+    do {
+        return try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions())
+    } catch {
+        print(error)
+    }
+    return nil;
 }
 
 private func parseForm(data:NSData, string:String) -> AnyObject?{
@@ -74,8 +78,12 @@ private func parseForm(data:NSData, string:String) -> AnyObject?{
 //SERIALIZERS
 private func serializeJson(data:AnyObject) -> NSData? {
     if(data as? Array<AnyObject> != nil || data as? Dictionary<String, AnyObject> != nil){
-        var error:NSError?
-        return NSJSONSerialization.dataWithJSONObject(data, options: NSJSONWritingOptions(), error: &error)
+        //var error:NSError?
+        do {
+            return try NSJSONSerialization.dataWithJSONObject(data, options: NSJSONWritingOptions())
+        } catch {
+            print(error)
+        }
     }
     else if let dataString = data as? String{
         return stringToData(dataString)
@@ -87,7 +95,7 @@ private func serializeForm(data:AnyObject) -> NSData? {
     if let queryString = queryString(data) {
         return stringToData(queryString)
     }
-    else if let dataString = (data as? String ?? toString(data)) as String? {
+    else if let dataString = (data as? String ?? String(data)) as String? {
         return stringToData(dataString)
     }
     

--- a/SwiftClient/FormData.swift
+++ b/SwiftClient/FormData.swift
@@ -31,7 +31,7 @@ internal class FormData {
     }
     
     private func determineMimeType(filename:String) -> String {
-        let type = filename.pathExtension
+        let type = NSURL(string: filename)!.pathExtension!
         
         if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, type as NSString, nil)?.takeRetainedValue() {
             if let mimetype = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() {

--- a/SwiftClient/Info.plist
+++ b/SwiftClient/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>theadam.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftClient/Request.swift
+++ b/SwiftClient/Request.swift
@@ -90,7 +90,7 @@ public class Request {
     /// Adds query params on the URL from a dictionary
     public func query(query:[String : String]) -> Request{
         for (key,value) in query {
-            self.query.append(queryPair(key, value));
+            self.query.append(queryPair(key, value: value))
         }
         return self;
     }
@@ -200,7 +200,7 @@ public class Request {
     public func attach(name:String, _ path:String, _ filename:String? = nil, withMimeType mimeType:String? = nil) -> Request {
         var basename:String! = filename;
         if(filename == nil){
-            basename = path.lastPathComponent;
+            basename = NSURL(string: path)!.lastPathComponent;
         }
         let data = NSData(contentsOfFile: path)
         
@@ -230,7 +230,7 @@ public class Request {
             if(self.formData != nil) {
                 request.HTTPBody = self.formData!.getBody();
                 self.type(self.formData!.getContentType());
-                self.set("Content-Length", toString(request.HTTPBody?.length));
+                self.set("Content-Length", String(request.HTTPBody?.length));
             }
             else if(self.data != nil){
                 if let data = self.data! as? NSData {
@@ -241,7 +241,7 @@ public class Request {
                         request.HTTPBody = serializer(self.data!)
                     }
                     else {
-                        request.HTTPBody = stringToData(toString(self.data!))
+                        request.HTTPBody = stringToData(String(self.data!))
                     }
                 }
             }
@@ -252,15 +252,15 @@ public class Request {
         }
                 
         let task = session.dataTaskWithRequest(request, completionHandler:
-            {(data: NSData?, response: NSURLResponse?, error: NSError!) -> Void in
+            {(data: NSData?, response: NSURLResponse?, error: NSError?) -> Void in
                 if let response = response as? NSHTTPURLResponse {
                     done(self.transformer(Response(response, self, data)));
                 }
                 else if errorHandler != nil {
-                    errorHandler!(error);
+                    errorHandler!(error!);
                 }
                 else {
-                    self.errorHandler(error);
+                    self.errorHandler(error!);
                 }
             }
         );

--- a/SwiftClient/Response.swift
+++ b/SwiftClient/Response.swift
@@ -11,6 +11,7 @@ import Foundation
 
 public class Response{
     
+    // MARK: - Variables and constraints
     public var text: String?;
     public var data: NSData?;
     public var body: AnyObject?;
@@ -18,31 +19,22 @@ public class Response{
     public var type: String?;
     public var charset: String?;
     
-    public let status: Int;
-    public let statusType: Int;
-    
-    public let info: Bool;
-    public let ok: Bool;
-    public let clientError: Bool;
-    public let serverError: Bool;
     public let error: Bool;
     
-    public let accepted: Bool;
-    public let noContent: Bool;
-    public let badRequest: Bool;
-    public let unauthorized: Bool;
-    public let notAcceptable: Bool;
-    public let notFound: Bool;
-    public let forbidden: Bool;
+    public let status: ResponseType
+    public let basicStatus: BasicResponseType
     
     public let request:Request;
     
     public var headers: [String : String];
     
+    // MARK: - Methods and class initializers,
+    // Trimming a string
     private func trim(s:String) -> String{
         return s.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet());
     }
     
+    // Splitting content parameters
     private func splitContentParams(params: [String]) -> [String : String]{
         return params.reduce(Dictionary(), combine: {(var map: [String : String], pair: String) -> [String : String] in
             var pairArray = pair.componentsSeparatedByString("=");
@@ -53,57 +45,118 @@ public class Response{
         });
     }
     
+    // Initializer of the Response class.
     init(_ response: NSHTTPURLResponse, _ request: Request, _ rawData: NSData?){
-        
         self.request = request;
-        
-        let status = response.statusCode;
         let type = response.statusCode / 100 | 0;
-        
-        // status / class
-        self.status = status;
-        self.statusType = type;
+        self.error = type == 4 || type == 5
 
         // basics
-        self.info = 1 == type;
-        self.ok = 2 == type;
-        self.clientError = 4 == type;
-        self.serverError = 5 == type;
-        self.error = 4 == type || 5 == type;
+        switch(type) {
+        case 1:
+            self.basicStatus = BasicResponseType.Info
+            break
+        case 2:
+            self.basicStatus = BasicResponseType.OK
+            break
+        case 4:
+            self.basicStatus = BasicResponseType.ClientError
+            break
+        case 5:
+            self.basicStatus = BasicResponseType.ServerError
+            break
+        default:
+            self.basicStatus = BasicResponseType.Unknown
+            print("Couldn't figure out the basic status code. (\(type))")
+            break
+        }
         
         // sugar
-        self.accepted = 202 == status;
-        self.noContent = 204 == status
-        self.badRequest = 400 == status;
-        self.unauthorized = 401 == status;
-        self.notAcceptable = 406 == status;
-        self.notFound = 404 == status;
-        self.forbidden = 403 == status;
+        switch(response.statusCode) {
+        case 200:
+            self.status = ResponseType.OK
+            break
+        case 201:
+            self.status = ResponseType.Created
+            break
+        case 202:
+            self.status = ResponseType.Accepted
+            break
+        case 204:
+            self.status = ResponseType.NoContent
+            break
+        case 400:
+            self.status = ResponseType.BadRequest
+            break
+        case 401:
+            self.status = ResponseType.Unauthorized
+            break
+        case 403:
+            self.status = ResponseType.Forbidden
+            break
+        case 404:
+            self.status = ResponseType.NotFound
+            break
+        case 406:
+            self.status = ResponseType.NotAcceptable
+            break
+        default:
+            self.status = ResponseType.Unknown
+            print("Couldn't set responseType (\(response.statusCode))")
+            break
+        }
         
         // header filling
-        headers = Dictionary();
+        headers = Dictionary()
         for (key, value) in response.allHeaderFields {
-            headers.updateValue(value.description, forKey: key.description.lowercaseString);
-        }
-
-        if let type = headers["content-type"] {
-            var typeArray = type.componentsSeparatedByString(";");
-            self.type = trim(typeArray.removeAtIndex(0));
-            let params = splitContentParams(typeArray);
-            self.charset = params["charset"];
+            headers.updateValue(value.description, forKey: key.description.lowercaseString)
         }
         
-        self.data = rawData;
-        self.body = rawData;
+        // filling charset
+        if let type = headers["content-type"] {
+            var typeArray = type.componentsSeparatedByString(";")
+            self.type = trim(typeArray.removeAtIndex(0))
+            let params = splitContentParams(typeArray)
+            self.charset = params["charset"]
+        }
+        
+        // setting raw data into variables.
+        self.data = rawData
+        self.body = rawData
         if let data = rawData {
-            self.text = dataToString(data);
+            self.text = dataToString(data)
             if let type = self.type {
                 if let parser = parsers[type] {
-                    self.body = parser(data, string:self.text!);
+                    self.body = parser(data, string:self.text!)
                 }
             }
         }
     }
+    
+    // MARK: - Response enums.
+    // ResponseType enum. Basically the status code of the response
+    public enum ResponseType {
+        case OK             // 200
+        case Created        // 201
+        case Accepted       // 202
+        case NoContent      // 204
+        case BadRequest     // 400
+        case Unauthorized   // 401
+        case Forbidden      // 403
+        case NotFound       // 404
+        case NotAcceptable  // 406
+        case Unknown        // ???
+    }
+    
+    // BasicResponseType enum. Status codes divided by 100.
+    public enum BasicResponseType {
+        case Info           // 1
+        case OK             // 2
+        case ClientError    // 4
+        case ServerError    // 5
+        case Unknown        // ?
+    }
 }
+
 
 

--- a/SwiftClient/Response.swift
+++ b/SwiftClient/Response.swift
@@ -99,7 +99,7 @@ public class Response{
             self.text = dataToString(data);
             if let type = self.type {
                 if let parser = parsers[type] {
-                    self.body = parser(data, self.text!);
+                    self.body = parser(data, string:self.text!);
                 }
             }
         }

--- a/SwiftClientTests/Info.plist
+++ b/SwiftClientTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>theadam.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftClientTests/SwiftClientTests.swift
+++ b/SwiftClientTests/SwiftClientTests.swift
@@ -14,7 +14,7 @@ class SwiftClientTests: XCTestCase {
     private func wait(){
         waitForExpectationsWithTimeout(5, handler: { error in
             if error != nil {
-                println("test timed out with error \(error)");
+                print("test timed out with error \(error)");
             }
         });
     }
@@ -305,7 +305,7 @@ class SwiftClientTests: XCTestCase {
             let json = Body(res.body);
             XCTAssertEqual(json["authenticated"].value as! Int, 1, "authenticated should be equal to 1")
             XCTAssertEqual(json["user"].value as! String, "username", "user should be equal to 1")
-            println(json);
+            print(json);
             self.expectation.fulfill();
         }
         request.get("/hidden-basic-auth/username/password")

--- a/SwiftClientTests/SwiftClientTests.swift
+++ b/SwiftClientTests/SwiftClientTests.swift
@@ -46,7 +46,7 @@ class SwiftClientTests: XCTestCase {
     
     func testHeadersFromDictionary(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
             XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
@@ -60,7 +60,7 @@ class SwiftClientTests: XCTestCase {
     
     func testHeadersFromKeyValue(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
             XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
@@ -74,7 +74,7 @@ class SwiftClientTests: XCTestCase {
     
     func testHeadersMixture(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
             XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
@@ -91,7 +91,7 @@ class SwiftClientTests: XCTestCase {
     
     func testRequestMiddleware(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
             XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
@@ -105,7 +105,7 @@ class SwiftClientTests: XCTestCase {
     
     func testResponseMiddleware(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = res.body as! Body;
             // the service capitalizes the headers ....
             XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
@@ -120,7 +120,7 @@ class SwiftClientTests: XCTestCase {
     
     func testType(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = res.body as! Body;
             // the service capitalizes the headers ....
             XCTAssertEqual(json["headers"]["Content-Type"].value as! String, "application/json", "header should have been sent");
@@ -144,7 +144,7 @@ class SwiftClientTests: XCTestCase {
     
     func testQueryAsDictionary(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             XCTAssertEqual(json["args"]["this has some spaces"].value! as! String, "this does too", "query arguments should match");
             self.expectation.fulfill();
@@ -157,7 +157,7 @@ class SwiftClientTests: XCTestCase {
     
     func testQueryAsKeyValue(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             XCTAssertEqual(json["args"]["key"].value! as! String, "value", "query arguments should match");
             self.expectation.fulfill();
@@ -170,7 +170,7 @@ class SwiftClientTests: XCTestCase {
     
     func testQueryMixture(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             XCTAssertEqual(json["args"]["key"].value! as! String, "value", "query arguments should match");
             XCTAssertEqual(json["args"]["this has some spaces"].value! as! String, "this does too", "query arguments should match");
@@ -186,7 +186,7 @@ class SwiftClientTests: XCTestCase {
     
     func testSendDictionary(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             XCTAssertEqual(json["json"]["key"].value! as! String, "value", "json should be equal");
             XCTAssertEqual(json["json"]["key2"].value! as! String, "value2", "json should be equal");
@@ -201,7 +201,7 @@ class SwiftClientTests: XCTestCase {
     
     func testSendString(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let form = Body(res.body);
             XCTAssertEqual(form["form"]["key"].value! as! String, "value", "json should be equal");
             XCTAssertEqual(form["form"]["key2"].value! as! String, "value2", "json should be equal");
@@ -216,7 +216,7 @@ class SwiftClientTests: XCTestCase {
     
     func testSendStringNoForm(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let content = Body(res.body);
             XCTAssertEqual(content["data"].value! as! String, "<html></html>", "html should have been sent");
             self.expectation.fulfill();
@@ -231,7 +231,7 @@ class SwiftClientTests: XCTestCase {
     
     func testSendOther(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let content = Body(res.body);
             XCTAssertEqual(content["json"].value! as! [Int], [1,2,3,4,5,6], "array should have been sent");
             self.expectation.fulfill();
@@ -245,7 +245,7 @@ class SwiftClientTests: XCTestCase {
     
     func testBaseUrlOverride(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             self.expectation.fulfill();
         }
         request.get("http://httpbin.org/headers")
@@ -301,7 +301,7 @@ class SwiftClientTests: XCTestCase {
     
     func testAuth(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             XCTAssertEqual(json["authenticated"].value as! Int, 1, "authenticated should be equal to 1")
             XCTAssertEqual(json["user"].value as! String, "username", "user should be equal to 1")
@@ -316,7 +316,7 @@ class SwiftClientTests: XCTestCase {
     
     func testMultipartFields(){
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let form = Body(res.body)["form"];
             XCTAssertEqual(form["key"].value as! String, "value", "form data should have been sent");
             XCTAssertEqual(form["key2"].value as! String, "value2", "form data should have been sent");
@@ -333,7 +333,7 @@ class SwiftClientTests: XCTestCase {
         var htmlString1 = "<html><body>1</body></html>";
         var htmlString2 = "<html><body>2</body></html>";
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
             XCTAssertEqual(files["file1"].value as! String, htmlString1, "form data should have been sent");
             XCTAssertEqual(files["file2"].value as! String, htmlString2, "form data should have been sent");
@@ -350,7 +350,7 @@ class SwiftClientTests: XCTestCase {
         var htmlString1 = "<html><body>1</body></html>";
         var htmlString2 = "<html><body>2</body></html>";
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
             XCTAssertEqual(files["file1"].value as! String, htmlString1, "form data should have been sent");
             XCTAssertEqual(files["file2"].value as! String, htmlString2, "form data should have been sent");
@@ -371,7 +371,7 @@ class SwiftClientTests: XCTestCase {
     func testMultipartFilesWithMime(){
         var htmlString1 = "<html><body>1</body></html>";
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
             XCTAssertEqual(files["file1"].value as! String, htmlString1, "form data should have been sent");
             self.expectation.fulfill();
@@ -387,7 +387,7 @@ class SwiftClientTests: XCTestCase {
         var fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
         
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
             XCTAssertEqual(files["file1"].value as! NSString, fileContents, "form data should have been sent");
             self.expectation.fulfill();
@@ -403,7 +403,7 @@ class SwiftClientTests: XCTestCase {
         var fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
         
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
             XCTAssertEqual(files["file1"].value as! NSString, fileContents, "form data should have been sent");
             self.expectation.fulfill();
@@ -419,7 +419,7 @@ class SwiftClientTests: XCTestCase {
         var fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
         
         let done = { (res: Response) -> Void in
-            XCTAssertEqual(res.ok, true);
+            XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
             XCTAssertEqual(files["file1"].value as! NSString, fileContents, "form data should have been sent");
             self.expectation.fulfill();


### PR DESCRIPTION
Hey,

I found this repo a week ago and when I tried to use it in my project, it gave me many syntax errors and issues with Travis. I converted the project to Swift 2 (xcode 7)

As for the Response class, it had countless booleans stored which could easily be replaced with a single variable. For that, I had to create two enumerations and added some switch cases in the init() of Response.

All unit tests turned positive and were also changed because of the new way of Response HTTP status code validation.

Travis: https://travis-ci.org/kevto/SwiftClient/builds/81558121