### PR TITLE
Add more http error codes

### DIFF
--- a/SwiftClient.xcodeproj/project.pbxproj
+++ b/SwiftClient.xcodeproj/project.pbxproj
@@ -386,10 +386,7 @@
 		D0CB88F019FC645300DA6940 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -404,10 +401,7 @@
 		D0CB88F119FC645300DA6940 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = SwiftClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "theadam.$(PRODUCT_NAME:rfc1034identifier)";

--- a/SwiftClient/FormData.swift
+++ b/SwiftClient/FormData.swift
@@ -48,7 +48,7 @@ internal class FormData {
     internal func getBody() -> NSData? {
         if(fields.count > 0 || files.count > 0){
             
-            var body = NSMutableData();
+            let body = NSMutableData();
             
             for (field) in fields {
                 appendField(body, field.name, field.value)

--- a/SwiftClient/Request.swift
+++ b/SwiftClient/Request.swift
@@ -54,7 +54,7 @@ public class Request {
     
     /// Stores a response transformer to be used on the received HTTP response
     public func transform(transformer: (Response) -> Response) -> Request{
-        var oldTransformer = self.transformer;
+        let oldTransformer = self.transformer;
         self.transformer = {(response:Response) -> Response in
             return transformer(oldTransformer(response));
         }
@@ -127,7 +127,7 @@ public class Request {
             self.data = oldData + data;
         }
         else{
-            var oldData = self.data as? String ?? "";
+            let oldData = self.data as? String ?? "";
             self.data = oldData + data;
         }
         
@@ -222,7 +222,7 @@ public class Request {
         
         let session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration(), delegate: self.delegate, delegateQueue: queue);
         
-        var request = NSMutableURLRequest(URL: NSURL(string: self.url)!, cachePolicy: NSURLRequestCachePolicy.UseProtocolCachePolicy, timeoutInterval: NSTimeInterval(self.timeout));
+        let request = NSMutableURLRequest(URL: NSURL(string: self.url)!, cachePolicy: NSURLRequestCachePolicy.UseProtocolCachePolicy, timeoutInterval: NSTimeInterval(self.timeout));
         
         request.HTTPMethod = self.method;
         

--- a/SwiftClient/Response.swift
+++ b/SwiftClient/Response.swift
@@ -21,7 +21,7 @@ public class Response{
     
     public let error: Bool;
     
-    public let status: ResponseType
+    public var status: ResponseType
     public let basicStatus: BasicResponseType
     
     public let request:Request;
@@ -100,6 +100,15 @@ public class Response{
         case 406:
             self.status = ResponseType.NotAcceptable
             break
+        case 412:
+            self.status = ResponseType.PreConditionFail
+            break
+        case 419:
+            self.status = ResponseType.AuthenticationTimeout
+            break
+        case 429:
+            self.status = ResponseType.TooManyRequests
+            break
         default:
             self.status = ResponseType.Unknown
             print("Couldn't set responseType (\(response.statusCode))")
@@ -136,16 +145,19 @@ public class Response{
     // MARK: - Response enums.
     // ResponseType enum. Basically the status code of the response
     public enum ResponseType {
-        case OK             // 200
-        case Created        // 201
-        case Accepted       // 202
-        case NoContent      // 204
-        case BadRequest     // 400
-        case Unauthorized   // 401
-        case Forbidden      // 403
-        case NotFound       // 404
-        case NotAcceptable  // 406
-        case Unknown        // ???
+        case OK                    // 200
+        case Created               // 201
+        case Accepted              // 202
+        case NoContent             // 204
+        case BadRequest            // 400
+        case Unauthorized          // 401
+        case Forbidden             // 403
+        case NotFound              // 404
+        case NotAcceptable         // 406
+        case PreConditionFail      // 412
+        case AuthenticationTimeout // 419
+        case TooManyRequests       // 429
+        case Unknown               // ???
     }
     
     // BasicResponseType enum. Status codes divided by 100.

--- a/SwiftClientTests/SwiftClientTests.swift
+++ b/SwiftClientTests/SwiftClientTests.swift
@@ -7,7 +7,8 @@
 //
 
 import XCTest
-import SwiftClient
+@testable import SwiftClient
+
 
 class SwiftClientTests: XCTestCase {
     
@@ -49,7 +50,7 @@ class SwiftClientTests: XCTestCase {
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
-            XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
+            XCTAssertEqual(json["headers"]["X-Header-Key"].value as? String, "headerValue", "header should have been sent");
             self.expectation.fulfill();
         }
         request.get("/headers")
@@ -63,7 +64,7 @@ class SwiftClientTests: XCTestCase {
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
-            XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
+            XCTAssertEqual(json["headers"]["X-Header-Key"].value as? String, "headerValue", "header should have been sent");
             self.expectation.fulfill();
         }
         request.get("/headers")
@@ -77,8 +78,8 @@ class SwiftClientTests: XCTestCase {
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
-            XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
-            XCTAssertEqual(json["headers"]["X-Header-Key2"].value as! String, "headerValue2", "header should have been sent");
+            XCTAssertEqual(json["headers"]["X-Header-Key"].value as? String, "headerValue", "header should have been sent");
+            XCTAssertEqual(json["headers"]["X-Header-Key2"].value as? String, "headerValue2", "header should have been sent");
             self.expectation.fulfill();
         }
         request.get("/headers")
@@ -94,7 +95,7 @@ class SwiftClientTests: XCTestCase {
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
             // the service capitalizes the headers ....
-            XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
+            XCTAssertEqual(json["headers"]["X-Header-Key"].value as? String, "headerValue", "header should have been sent");
             self.expectation.fulfill();
         }
         request.get("/headers")
@@ -108,7 +109,7 @@ class SwiftClientTests: XCTestCase {
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = res.body as! Body;
             // the service capitalizes the headers ....
-            XCTAssertEqual(json["headers"]["X-Header-Key"].value as! String, "headerValue", "header should have been sent");
+            XCTAssertEqual(json["headers"]["X-Header-Key"].value as? String, "headerValue", "header should have been sent");
             self.expectation.fulfill();
         }
         request.get("/headers")
@@ -123,7 +124,7 @@ class SwiftClientTests: XCTestCase {
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = res.body as! Body;
             // the service capitalizes the headers ....
-            XCTAssertEqual(json["headers"]["Content-Type"].value as! String, "application/json", "header should have been sent");
+            XCTAssertEqual(json["headers"]["Content-Type"].value as? String, "application/json", "header should have been sent");
             self.expectation.fulfill();
         }
         request.get("/headers")
@@ -134,7 +135,7 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testGetHeader(){
-        var r = request.get("/headers")
+        let r = request.get("/headers")
             .type("json");
         
         XCTAssertEqual(r.getHeader("content-TYPE")!, "application/json", "headers should match");
@@ -146,7 +147,7 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
-            XCTAssertEqual(json["args"]["this has some spaces"].value! as! String, "this does too", "query arguments should match");
+            XCTAssertEqual(json["args"]["this has some spaces"].value! as? String, "this does too", "query arguments should match");
             self.expectation.fulfill();
         }
         request.get("/get")
@@ -159,7 +160,7 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
-            XCTAssertEqual(json["args"]["key"].value! as! String, "value", "query arguments should match");
+            XCTAssertEqual(json["args"]["key"].value! as? String, "value", "query arguments should match");
             self.expectation.fulfill();
         }
         request.get("/get")
@@ -172,9 +173,9 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
-            XCTAssertEqual(json["args"]["key"].value! as! String, "value", "query arguments should match");
-            XCTAssertEqual(json["args"]["this has some spaces"].value! as! String, "this does too", "query arguments should match");
-            XCTAssertEqual(json["args"]["withParam"].value! as! String, "5", "query arguments should match");
+            XCTAssertEqual(json["args"]["key"].value! as? String, "value", "query arguments should match");
+            XCTAssertEqual(json["args"]["this has some spaces"].value! as? String, "this does too", "query arguments should match");
+            XCTAssertEqual(json["args"]["withParam"].value! as? String, "5", "query arguments should match");
             self.expectation.fulfill();
         }
         request.get("/get?withParam=5")
@@ -188,8 +189,8 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
-            XCTAssertEqual(json["json"]["key"].value! as! String, "value", "json should be equal");
-            XCTAssertEqual(json["json"]["key2"].value! as! String, "value2", "json should be equal");
+            XCTAssertEqual(json["json"]["key"].value! as? String, "value", "json should be equal");
+            XCTAssertEqual(json["json"]["key2"].value! as? String, "value2", "json should be equal");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -203,8 +204,8 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let form = Body(res.body);
-            XCTAssertEqual(form["form"]["key"].value! as! String, "value", "json should be equal");
-            XCTAssertEqual(form["form"]["key2"].value! as! String, "value2", "json should be equal");
+            XCTAssertEqual(form["form"]["key"].value! as? String, "value", "json should be equal");
+            XCTAssertEqual(form["form"]["key2"].value! as? String, "value2", "json should be equal");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -218,7 +219,7 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let content = Body(res.body);
-            XCTAssertEqual(content["data"].value! as! String, "<html></html>", "html should have been sent");
+            XCTAssertEqual(content["data"].value! as? String, "<html></html>", "html should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -303,8 +304,8 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let json = Body(res.body);
-            XCTAssertEqual(json["authenticated"].value as! Int, 1, "authenticated should be equal to 1")
-            XCTAssertEqual(json["user"].value as! String, "username", "user should be equal to 1")
+            XCTAssertEqual(json["authenticated"].value as? Int, 1, "authenticated should be equal to 1")
+            XCTAssertEqual(json["user"].value as? String, "username", "user should be equal to 1")
             print(json);
             self.expectation.fulfill();
         }
@@ -318,8 +319,8 @@ class SwiftClientTests: XCTestCase {
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let form = Body(res.body)["form"];
-            XCTAssertEqual(form["key"].value as! String, "value", "form data should have been sent");
-            XCTAssertEqual(form["key2"].value as! String, "value2", "form data should have been sent");
+            XCTAssertEqual(form["key"].value as? String, "value", "form data should have been sent");
+            XCTAssertEqual(form["key2"].value as? String, "value2", "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -330,13 +331,13 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testMultipartFiles(){
-        var htmlString1 = "<html><body>1</body></html>";
-        var htmlString2 = "<html><body>2</body></html>";
+        let htmlString1 = "<html><body>1</body></html>";
+        let htmlString2 = "<html><body>2</body></html>";
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
-            XCTAssertEqual(files["file1"].value as! String, htmlString1, "form data should have been sent");
-            XCTAssertEqual(files["file2"].value as! String, htmlString2, "form data should have been sent");
+            XCTAssertEqual(files["file1"].value as? String, htmlString1, "form data should have been sent");
+            XCTAssertEqual(files["file2"].value as? String, htmlString2, "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -347,16 +348,16 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testMultipartMixed(){
-        var htmlString1 = "<html><body>1</body></html>";
-        var htmlString2 = "<html><body>2</body></html>";
+        let htmlString1 = "<html><body>1</body></html>";
+        let htmlString2 = "<html><body>2</body></html>";
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
-            XCTAssertEqual(files["file1"].value as! String, htmlString1, "form data should have been sent");
-            XCTAssertEqual(files["file2"].value as! String, htmlString2, "form data should have been sent");
+            XCTAssertEqual(files["file1"].value as? String, htmlString1, "form data should have been sent");
+            XCTAssertEqual(files["file2"].value as? String, htmlString2, "form data should have been sent");
             let form = Body(res.body)["form"];
-            XCTAssertEqual(form["key"].value as! String, "value", "form data should have been sent");
-            XCTAssertEqual(form["key2"].value as! String, "value2", "form data should have been sent");
+            XCTAssertEqual(form["key"].value as? String, "value", "form data should have been sent");
+            XCTAssertEqual(form["key2"].value as? String, "value2", "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -369,11 +370,11 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testMultipartFilesWithMime(){
-        var htmlString1 = "<html><body>1</body></html>";
+        let htmlString1 = "<html><body>1</body></html>";
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
-            XCTAssertEqual(files["file1"].value as! String, htmlString1, "form data should have been sent");
+            XCTAssertEqual(files["file1"].value as? String, htmlString1, "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -383,13 +384,13 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testMultipartPathFilesNoFileName(){
-        var filePath:String = NSBundle(forClass: self.classForCoder).pathForResource("test", ofType: "html")!;
-        var fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
+        let filePath:String = NSBundle(forClass: self.classForCoder).pathForResource("test", ofType: "html")!;
+        let fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
         
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
-            XCTAssertEqual(files["file1"].value as! NSString, fileContents, "form data should have been sent");
+            XCTAssertEqual(files["file1"].value as? NSString, fileContents, "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -399,13 +400,13 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testMultipartPathFilesNoMimeType(){
-        var filePath:String = NSBundle(forClass: self.classForCoder).pathForResource("test", ofType: "html")!;
-        var fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
+        let filePath:String = NSBundle(forClass: self.classForCoder).pathForResource("test", ofType: "html")!;
+        let fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
         
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
-            XCTAssertEqual(files["file1"].value as! NSString, fileContents, "form data should have been sent");
+            XCTAssertEqual(files["file1"].value as? NSString, fileContents, "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -415,13 +416,13 @@ class SwiftClientTests: XCTestCase {
     }
     
     func testMultipartPathFilesMimeType(){
-        var filePath:String = NSBundle(forClass: self.classForCoder).pathForResource("test", ofType: "html")!;
-        var fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
+        let filePath:String = NSBundle(forClass: self.classForCoder).pathForResource("test", ofType: "html")!;
+        let fileContents = NSString(data: NSData(contentsOfFile: filePath)!, encoding: NSUTF8StringEncoding)!;
         
         let done = { (res: Response) -> Void in
             XCTAssertEqual(res.status, Response.ResponseType.OK);
             let files = Body(res.body)["files"];
-            XCTAssertEqual(files["file1"].value as! NSString, fileContents, "form data should have been sent");
+            XCTAssertEqual(files["file1"].value as? NSString, fileContents, "form data should have been sent");
             self.expectation.fulfill();
         }
         request.post("/post")
@@ -429,6 +430,79 @@ class SwiftClientTests: XCTestCase {
             .end(done, onError: self.defaultError);
         wait();
     }
+
+    func testBasicResponseTypeCodes(){
+        let basicResponseCodes: [Int : Response.BasicResponseType] = [1: Response.BasicResponseType.Info,
+            2: Response.BasicResponseType.OK,
+            4: Response.BasicResponseType.ClientError,
+            5: Response.BasicResponseType.ServerError]
+        
+        for code in basicResponseCodes {
+            
+            /// The first iteration should fulfill the setUp() expectation.
+            if (Array(basicResponseCodes.keys)[0] != code.0){
+                
+                /// Create new expectations for the other ResponseType codes.
+                expectation = expectationWithDescription(String(format: "BasicResponseType Code: %i", code.0))
+            }
+            
+            let done = { (res: Response) -> Void in
+                XCTAssertEqual(res.basicStatus, code.1);
+                self.expectation.fulfill()
+            }
+            
+            request.get("/basicResponseTypeCodes")
+                .transform({ (response: Response) -> Response in
+                    let mockResponse = NSHTTPURLResponse(URL: NSURL(fileURLWithPath: "foobar"), statusCode: (code.0*100), HTTPVersion: "foo", headerFields: nil)
+                    let mockRequest = Request("foo", "bar", {(error: NSError) -> Void in})
+                    
+                    return Response(mockResponse!, mockRequest, nil)
+                })
+                .end(done, onError: self.defaultError);
+            
+            wait();
+        }
+    }
+    
+    func testResponseTypeCodes(){
+        let responseCodes: [Int : Response.ResponseType] = [200: Response.ResponseType.OK,
+            201: Response.ResponseType.Created,
+            202: Response.ResponseType.Accepted,
+            204: Response.ResponseType.NoContent,
+            400: Response.ResponseType.BadRequest,
+            401: Response.ResponseType.Unauthorized,
+            403: Response.ResponseType.Forbidden,
+            404: Response.ResponseType.NotFound,
+            406: Response.ResponseType.NotAcceptable,
+            412: Response.ResponseType.PreConditionFail,
+            419: Response.ResponseType.AuthenticationTimeout,
+            429: Response.ResponseType.TooManyRequests]
+        
+        for code in responseCodes {
+            
+            /// The first iteration should fulfill the setUp() expectation.
+            if (Array(responseCodes.keys)[0] != code.0){
+                
+                /// Create new expectations for the other ResponseType codes.
+                expectation = expectationWithDescription(String(format: "ResponseType Code: %i", code.0))
+            }
+            
+            let done = { (res: Response) -> Void in
+                XCTAssertEqual(res.status, code.1);
+                self.expectation.fulfill()
+            }
+            
+            request.get("/responseTypeCodes")
+                .transform({ (response: Response) -> Response in
+                    let mockResponse = NSHTTPURLResponse(URL: NSURL(fileURLWithPath: "foobar"), statusCode: code.0, HTTPVersion: "foo", headerFields: nil)
+                    let mockRequest = Request("foo", "bar", {(error: NSError) -> Void in})
+                    
+                    return Response(mockResponse!, mockRequest, nil)
+                })
+                .end(done, onError: self.defaultError);
+            
+            wait();
+        }
+    }
     
 }
-


### PR DESCRIPTION
This pull request adds 3 more HTTP error codes: 412, 419, 429.
It also fixes all the SwiftClient build warnings and introduces tests for the BasicResponseType codes and ResponseType codes. 