### PR TITLE
Add attribute statusCode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode7.1
 
 script:
   - xcodebuild clean build test -project SwiftClient.xcodeproj -scheme SwiftClient -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/SwiftClient/Response.swift
+++ b/SwiftClient/Response.swift
@@ -61,6 +61,9 @@ public class Response{
         case 2:
             self.basicStatus = BasicResponseType.OK
             break
+        case 3:
+            self.basicStatus = BasicResponseType.Redirection
+            break
         case 4:
             self.basicStatus = BasicResponseType.ClientError
             break
@@ -84,8 +87,41 @@ public class Response{
         case 202:
             self.status = ResponseType.Accepted
             break
+        case 203:
+            self.status = ResponseType.NonAuthoritativeInfo
+            break
         case 204:
             self.status = ResponseType.NoContent
+            break
+        case 205:
+            self.status = ResponseType.ResetContent
+            break
+        case 206:
+            self.status = ResponseType.PartialContent
+            break
+        case 207:
+            self.status = ResponseType.MultiStatus
+            break
+        case 300:
+            self.status = ResponseType.MultipleChoices
+            break
+        case 301:
+            self.status = ResponseType.MovedPermanently
+            break
+        case 302:
+            self.status = ResponseType.Found
+            break
+        case 303:
+            self.status = ResponseType.SeeOther
+            break
+        case 304:
+            self.status = ResponseType.NotModified
+            break
+        case 305:
+            self.status = ResponseType.UseProxy
+            break
+        case 307:
+            self.status = ResponseType.TemporaryRedirect
             break
         case 400:
             self.status = ResponseType.BadRequest
@@ -93,17 +129,53 @@ public class Response{
         case 401:
             self.status = ResponseType.Unauthorized
             break
+        case 402:
+            self.status = ResponseType.PaymentRequired
+            break
         case 403:
             self.status = ResponseType.Forbidden
             break
         case 404:
             self.status = ResponseType.NotFound
             break
+        case 405:
+            self.status = ResponseType.MethodNotAllowed
+            break
         case 406:
             self.status = ResponseType.NotAcceptable
             break
+        case 407:
+            self.status = ResponseType.ProxyAuthentication
+            break
+        case 408:
+            self.status = ResponseType.RequestTimeout
+            break
+        case 409:
+            self.status = ResponseType.Conflict
+            break
+        case 410:
+            self.status = ResponseType.Gone
+            break
+        case 411:
+            self.status = ResponseType.LengthRequired
+            break
         case 412:
             self.status = ResponseType.PreConditionFail
+            break
+        case 413:
+            self.status = ResponseType.RequestEntityTooLarge
+            break
+        case 414:
+            self.status = ResponseType.RequestURITooLong
+            break
+        case 415:
+            self.status = ResponseType.UnsupportedMediaType
+            break
+        case 416:
+            self.status = ResponseType.RequestedRangeNotSatisfiable
+            break
+        case 417:
+            self.status = ResponseType.ExpectationFailed
             break
         case 419:
             self.status = ResponseType.AuthenticationTimeout
@@ -111,9 +183,26 @@ public class Response{
         case 429:
             self.status = ResponseType.TooManyRequests
             break
+        case 500:
+            self.status = ResponseType.InternalServerError
+            break
+        case 501:
+            self.status = ResponseType.NotImplemented
+            break
+        case 502:
+            self.status = ResponseType.BadGateway
+            break
+        case 503:
+            self.status = ResponseType.ServiceUnavailable
+            break
+        case 504:
+            self.status = ResponseType.GatewayTimeout
+            break
+        case 505:
+            self.status = ResponseType.HTTPVersionNotSupported
+            break
         default:
             self.status = ResponseType.Unknown
-            print("Couldn't set responseType (\(response.statusCode))")
             break
         }
         
@@ -147,25 +236,55 @@ public class Response{
     // MARK: - Response enums.
     // ResponseType enum. Basically the status code of the response
     public enum ResponseType {
-        case OK                    // 200
-        case Created               // 201
-        case Accepted              // 202
-        case NoContent             // 204
-        case BadRequest            // 400
-        case Unauthorized          // 401
-        case Forbidden             // 403
-        case NotFound              // 404
-        case NotAcceptable         // 406
-        case PreConditionFail      // 412
-        case AuthenticationTimeout // 419
-        case TooManyRequests       // 429
-        case Unknown               // ???
+        case OK                            // 200
+        case Created                       // 201
+        case Accepted                      // 202
+        case NonAuthoritativeInfo          // 203
+        case NoContent                     // 204
+        case ResetContent                  // 205
+        case PartialContent                // 206
+        case MultiStatus                   // 207
+        case MultipleChoices               // 300
+        case MovedPermanently              // 301
+        case Found                         // 302
+        case SeeOther                      // 303
+        case NotModified                   // 304
+        case UseProxy                      // 305
+        case TemporaryRedirect             // 307
+        case BadRequest                    // 400
+        case Unauthorized                  // 401
+        case PaymentRequired               // 402
+        case Forbidden                     // 403
+        case NotFound                      // 404
+        case MethodNotAllowed              // 405
+        case NotAcceptable                 // 406
+        case ProxyAuthentication           // 407
+        case RequestTimeout                // 408
+        case Conflict                      // 409
+        case Gone                          // 410
+        case LengthRequired                // 411
+        case PreConditionFail              // 412
+        case RequestEntityTooLarge         // 413
+        case RequestURITooLong             // 414
+        case UnsupportedMediaType          // 415
+        case RequestedRangeNotSatisfiable  // 416
+        case ExpectationFailed             // 417
+        case AuthenticationTimeout         // 419
+        case TooManyRequests               // 429
+        case InternalServerError           // 500
+        case NotImplemented                // 501
+        case BadGateway                    // 502
+        case ServiceUnavailable            // 503
+        case GatewayTimeout                // 504
+        case HTTPVersionNotSupported       // 505
+        case Unknown                       // ???
     }
     
     // BasicResponseType enum. Status codes divided by 100.
     public enum BasicResponseType {
         case Info           // 1
         case OK             // 2
+        case Redirection    // 3
         case ClientError    // 4
         case ServerError    // 5
         case Unknown        // ?

--- a/SwiftClient/Response.swift
+++ b/SwiftClient/Response.swift
@@ -22,6 +22,7 @@ public class Response{
     public let error: Bool;
     
     public var status: ResponseType
+    public let statusCode: Int
     public let basicStatus: BasicResponseType
     
     public let request:Request;
@@ -48,6 +49,7 @@ public class Response{
     // Initializer of the Response class.
     init(_ response: NSHTTPURLResponse, _ request: Request, _ rawData: NSData?){
         self.request = request;
+        self.statusCode = response.statusCode
         let type = response.statusCode / 100 | 0;
         self.error = type == 4 || type == 5
 

--- a/SwiftClientTests/SwiftClientTests.swift
+++ b/SwiftClientTests/SwiftClientTests.swift
@@ -434,6 +434,7 @@ class SwiftClientTests: XCTestCase {
     func testBasicResponseTypeCodes(){
         let basicResponseCodes: [Int : Response.BasicResponseType] = [1: Response.BasicResponseType.Info,
             2: Response.BasicResponseType.OK,
+            3: Response.BasicResponseType.Redirection,
             4: Response.BasicResponseType.ClientError,
             5: Response.BasicResponseType.ServerError]
         
@@ -468,15 +469,44 @@ class SwiftClientTests: XCTestCase {
         let responseCodes: [Int : Response.ResponseType] = [200: Response.ResponseType.OK,
             201: Response.ResponseType.Created,
             202: Response.ResponseType.Accepted,
+            203: Response.ResponseType.NonAuthoritativeInfo,
             204: Response.ResponseType.NoContent,
+            205: Response.ResponseType.ResetContent,
+            206: Response.ResponseType.PartialContent,
+            207: Response.ResponseType.MultiStatus,
+            300: Response.ResponseType.MultipleChoices,
+            301: Response.ResponseType.MovedPermanently,
+            302: Response.ResponseType.Found,
+            303: Response.ResponseType.SeeOther,
+            304: Response.ResponseType.NotModified,
+            305: Response.ResponseType.UseProxy,
+            307: Response.ResponseType.TemporaryRedirect,
             400: Response.ResponseType.BadRequest,
             401: Response.ResponseType.Unauthorized,
+            402: Response.ResponseType.PaymentRequired,
             403: Response.ResponseType.Forbidden,
             404: Response.ResponseType.NotFound,
+            405: Response.ResponseType.MethodNotAllowed,
             406: Response.ResponseType.NotAcceptable,
+            407: Response.ResponseType.ProxyAuthentication,
+            408: Response.ResponseType.RequestTimeout,
+            409: Response.ResponseType.Conflict,
+            410: Response.ResponseType.Gone,
+            411: Response.ResponseType.LengthRequired,
             412: Response.ResponseType.PreConditionFail,
+            413: Response.ResponseType.RequestEntityTooLarge,
+            414: Response.ResponseType.RequestURITooLong,
+            415: Response.ResponseType.UnsupportedMediaType,
+            416: Response.ResponseType.RequestedRangeNotSatisfiable,
+            417: Response.ResponseType.ExpectationFailed,
             419: Response.ResponseType.AuthenticationTimeout,
-            429: Response.ResponseType.TooManyRequests]
+            429: Response.ResponseType.TooManyRequests,
+            500: Response.ResponseType.InternalServerError,
+            501: Response.ResponseType.NotImplemented,
+            502: Response.ResponseType.BadGateway,
+            503: Response.ResponseType.ServiceUnavailable,
+            504: Response.ResponseType.GatewayTimeout,
+            505: Response.ResponseType.HTTPVersionNotSupported]
         
         for code in responseCodes {
             

--- a/SwiftClientTests/SwiftClientTests.swift
+++ b/SwiftClientTests/SwiftClientTests.swift
@@ -488,6 +488,7 @@ class SwiftClientTests: XCTestCase {
             }
             
             let done = { (res: Response) -> Void in
+                XCTAssertEqual(res.statusCode, code.0)
                 XCTAssertEqual(res.status, code.1);
                 self.expectation.fulfill()
             }


### PR DESCRIPTION
This pull request adds the attribute `statusCode` to the Response model.
I think the library should expose the status code to be possible to distinguish between two different unhandled errors, for instance 501 and 503. 

I also added more HTTP status codes based on the [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html). This fixes an issue that when I get a success response with the status code 206 the SwiftClient prints the error `Couldn't set responseType (206)`.

@theadam do you have any ETA to the next release? 

Thanks for your work.