### PR TITLE
Add text/plain to content-type types

### DIFF
--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -119,7 +119,8 @@ internal let types = [
     "xml": "application/xml",
     "urlencoded": "application/x-www-form-urlencoded",
     "form": "application/x-www-form-urlencoded",
-    "form-data": "application/x-www-form-urlencoded"
+    "form-data": "application/x-www-form-urlencoded",
+    "text": "text/plain"
 ]
 
 internal let serializers = [

--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -62,7 +62,7 @@ open class Request {
     }
     
     /// Sets the content-type.  Can be set using shorthand.
-    /// ex: json, html, form, urlencoded, form, form-data, xml
+    /// ex: json, html, form, urlencoded, form, form-data, xml, text
     ///
     /// When not using shorthand, the value is used directory.
     open func type(type:String) -> Request {


### PR DESCRIPTION
This PR adds the `text/plain` type to the `content-type` header setter. 